### PR TITLE
Add container for large screens

### DIFF
--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,7 +32,7 @@ const Home = ({ events }) => {
           </p>
         </div>
       </div>
-      <div className="flex flex-col p-8 sm:pt-14 px-5 sm:px-20 text-left gap-y-4">
+      <div className="flex flex-col p-8 sm:pt-14 px-5 sm:px-20 text-left gap-y-4 lg:max-w-7xl mx-auto">
         <h1 className={`text-2xl sm:text-3xl font-bold underline ml-1 ${Object.keys(upcomingEvents).length === 0 ? 'hidden' : ''}`}>Upcoming events</h1>
         <div className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 gap-3 sm:auto-cols-fr text-center">
           {Object.keys(upcomingEvents).map(key => (          
@@ -60,7 +60,7 @@ const Home = ({ events }) => {
           </div>
         </div>
       )}
-      <div className="flex flex-col p-8 sm:pt-14 px-5 sm:px-20 text-left gap-y-4">
+      <div className="flex flex-col p-8 sm:pt-14 px-5 sm:px-20 text-left gap-y-4 lg:max-w-7xl mx-auto">
         <h1 className="text-2xl sm:text-3xl font-bold underline ml-1">Past events</h1>
         <div className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 gap-3 sm:auto-cols-fr text-center">
           {Object.keys(pastEvents).map(key => (          

--- a/pages/index.tsx
+++ b/pages/index.tsx
@@ -32,7 +32,7 @@ const Home = ({ events }) => {
           </p>
         </div>
       </div>
-      <div className="flex flex-col p-8 sm:pt-14 px-5 sm:px-20 text-left gap-y-4 lg:max-w-7xl mx-auto">
+      <div className="flex flex-col p-8 sm:pt-14 px-5 sm:px-20 text-left gap-y-4 lg:max-w-screen-2xl mx-auto">
         <h1 className={`text-2xl sm:text-3xl font-bold underline ml-1 ${Object.keys(upcomingEvents).length === 0 ? 'hidden' : ''}`}>Upcoming events</h1>
         <div className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 gap-3 sm:auto-cols-fr text-center">
           {Object.keys(upcomingEvents).map(key => (          
@@ -60,7 +60,7 @@ const Home = ({ events }) => {
           </div>
         </div>
       )}
-      <div className="flex flex-col p-8 sm:pt-14 px-5 sm:px-20 text-left gap-y-4 lg:max-w-7xl mx-auto">
+      <div className="flex flex-col p-8 sm:pt-14 px-5 sm:px-20 text-left gap-y-4 lg:max-w-screen-2xl mx-auto">
         <h1 className="text-2xl sm:text-3xl font-bold underline ml-1">Past events</h1>
         <div className="grid grid-cols-1 sm:grid-cols-3 lg:grid-cols-4 gap-3 sm:auto-cols-fr text-center">
           {Object.keys(pastEvents).map(key => (          


### PR DESCRIPTION
Previously, the main part of the page didn't have a max-width; so, on large screens the cards would span the entire width and look kind of flat. This PR adds a max width (and centers the cards) so that it looks better on large screens.

Prev:
<img width="1438" alt="Screen Shot 2021-11-22 at 1 08 32 AM" src="https://user-images.githubusercontent.com/72365100/142833753-1a1bd4f4-ed65-40c2-bb4a-9ecd96614572.png">

Now:
<img width="500" alt="Screen Shot 2021-11-22 at 1 17 01 AM" src="https://user-images.githubusercontent.com/72365100/142834680-2a230a4f-fd77-4730-a8cd-b411c95454de.png">
<img width="500" alt="Screen Shot 2021-11-22 at 1 16 58 AM" src="https://user-images.githubusercontent.com/72365100/142834687-fc014c55-01ec-42ce-90ac-c6da0b24df8f.png">

