### PR TITLE
Add UUID verification when confirming emails

### DIFF
--- a/components/styled-link.tsx
+++ b/components/styled-link.tsx
@@ -3,15 +3,14 @@ import Link from 'next/link'
 type StyledLinkProps = {
   destination: string;
   color?: string;
-  transitionColor?: string;
   newTab?: boolean;
   children?: any;
 }
 
-const StyledLink = ({ destination, color = "yellow-500", transitionColor = "yellow-400", newTab = false, ...props }: StyledLinkProps) => (
+const StyledLink = ({ destination, color = "text-yellow-500 hover:text-yellow-400", newTab = false, ...props }: StyledLinkProps) => (
   <span>
     <Link href={destination} passHref>
-      <a href="#" target={newTab ? "blank" : ""} className={`text-${color} hover:text-${transitionColor} transition`}>
+      <a href="#" target={newTab ? "blank" : ""} className={`${color} transition`}>
         {props.children}
       </a>
     </Link>

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -35,7 +35,3 @@ export const uuidIsValid = async (email: string, uuid: string): Promise<boolean>
 
   return emailRecord?.fields['UUID'] === uuid ?? false
 }
-
-export const deleteUUIDRecord = async (email: string): Promise<void> => {
-  await airtable.deleteWhere(`Email = '${email}'`).then((r) => console.log('Deleted', r))
-}

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -29,7 +29,8 @@ export const generateUUID = async (email: string): Promise<string> => {
 }
 
 export const verifyUUID = async (email: string, uuid: string): Promise<boolean> => {
-  if (typeof email === undefined || typeof uuid === undefined) return false
+  console.log(email, uuid)
+  if (email === undefined || uuid === undefined) return false
   const emailRecord = (await airtable.read({
     filterByFormula: `Email = '${email}'`
   }))[0]

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -28,7 +28,7 @@ export const generateUUID = async (email: string): Promise<string> => {
   return uuid
 }
 
-export const uuidIsValid = async (email: string|string[], uuid: string|string[]): Promise<boolean> => {
+export const uuidIsValid = async (email: string, uuid: string): Promise<boolean> => {
   const emailRecord = (await airtable.read({
     filterByFormula: `Email = '${email}'`
   }))[0]
@@ -36,6 +36,6 @@ export const uuidIsValid = async (email: string|string[], uuid: string|string[])
   return emailRecord?.fields['UUID'] === uuid ?? false
 }
 
-export const deleteUUIDRecord = async (email: string|string[]): Promise<void> => {
+export const deleteUUIDRecord = async (email: string): Promise<void> => {
   await airtable.deleteWhere(`Email = '${email}'`)
 }

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -12,7 +12,7 @@ export const generateUUID = async (email: string): Promise<void> => {
 
   const emailRecords = await airtable.read({
     filterByFormula: `Email = '${email}'`
-  }) as unknown as AirtablePlusPlusRecord<{ name: string; uuid: string }>[]
+  }) as unknown as AirtablePlusPlusRecord<{ email: string; uuid: string }>[]
 
   if (emailRecords.length === 0) {
     await airtable.create({
@@ -20,7 +20,7 @@ export const generateUUID = async (email: string): Promise<void> => {
       'UUID': uuid
     })
   } else {
-    await airtable.updateWhere(`Name = '${email}'`, {
+    await airtable.updateWhere(`Email = '${email}'`, {
       'UUID': uuid 
     })
   }

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -1,0 +1,36 @@
+import { v4 as uuidv4 } from 'uuid'
+import { AirtablePlusPlus, AirtablePlusPlusRecord } from 'airtable-plusplus'
+
+const airtable = new AirtablePlusPlus({
+  apiKey: `${process.env.AIRTABLE_API_KEY}`,
+  baseId: 'appfaalz9AzKDwSup',
+  tableName: 'Emails'
+})
+
+export const generateUUID = async (email: string): Promise<void> => {
+  const uuid = uuidv4()
+
+  const emailRecords = await airtable.read({
+    filterByFormula: `Email = '${email}'`
+  }) as unknown as AirtablePlusPlusRecord<{ name: string; uuid: string }>[]
+
+  if (emailRecords.length === 0) {
+    await airtable.create({
+      'Email': email,
+      'UUID': uuid
+    })
+  } else {
+    await airtable.updateWhere(`Name = '${email}'`, {
+      'UUID': uuid 
+    })
+  }
+}
+
+export const uuidIsValid = async (email: string, uuid: string): Promise<boolean> => {
+  const emailRecord = (await airtable.read({
+    filterByFormula: `Email = '${email}'`
+  }))[0]
+  if (typeof emailRecord === undefined) return false
+
+  return emailRecord.fields['UUID'] === uuid
+}

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -32,9 +32,8 @@ export const uuidIsValid = async (email: string|string[], uuid: string|string[])
   const emailRecord = (await airtable.read({
     filterByFormula: `Email = '${email}'`
   }))[0]
-  if (typeof emailRecord === undefined) return false
 
-  return emailRecord.fields['UUID'] === uuid
+  return emailRecord?.fields['UUID'] === uuid ?? false
 }
 
 export const deleteUUIDRecord = async (email: string|string[]): Promise<void> => {

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -7,7 +7,7 @@ const airtable = new AirtablePlusPlus({
   tableName: 'Emails'
 })
 
-export const generateUUID = async (email: string): Promise<void> => {
+export const generateUUID = async (email: string): Promise<string> => {
   const uuid = uuidv4()
 
   const emailRecords = await airtable.read({
@@ -24,13 +24,19 @@ export const generateUUID = async (email: string): Promise<void> => {
       'UUID': uuid 
     })
   }
+
+  return uuid
 }
 
-export const uuidIsValid = async (email: string, uuid: string): Promise<boolean> => {
+export const uuidIsValid = async (email: string|string[], uuid: string|string[]): Promise<boolean> => {
   const emailRecord = (await airtable.read({
     filterByFormula: `Email = '${email}'`
   }))[0]
   if (typeof emailRecord === undefined) return false
 
   return emailRecord.fields['UUID'] === uuid
+}
+
+export const deleteUUIDRecord = async (email: string|string[]): Promise<void> => {
+  await airtable.deleteWhere(`Email = '${email}'`)
 }

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -28,7 +28,8 @@ export const generateUUID = async (email: string): Promise<string> => {
   return uuid
 }
 
-export const uuidIsValid = async (email: string, uuid: string): Promise<boolean> => {
+export const verifyUUID = async (email: string, uuid: string): Promise<boolean> => {
+  if (typeof email === undefined || typeof uuid === undefined) return false
   const emailRecord = (await airtable.read({
     filterByFormula: `Email = '${email}'`
   }))[0]

--- a/lib/uuid.ts
+++ b/lib/uuid.ts
@@ -37,5 +37,5 @@ export const uuidIsValid = async (email: string, uuid: string): Promise<boolean>
 }
 
 export const deleteUUIDRecord = async (email: string): Promise<void> => {
-  await airtable.deleteWhere(`Email = '${email}'`)
+  await airtable.deleteWhere(`Email = '${email}'`).then((r) => console.log('Deleted', r))
 }

--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
   },
   "dependencies": {
     "@tailwindcss/forms": "^0.3.4",
+    "@types/uuid": "^8.3.3",
     "airtable-plusplus": "^0.3.2",
     "github-slugger-typescript": "^1.1.0",
     "lodash": "^4.17.21",
@@ -17,7 +18,8 @@
     "react": "^17.0.2",
     "react-dom": "^17.0.2",
     "react-feather": "^2.0.9",
-    "tinytime": "^0.2.6"
+    "tinytime": "^0.2.6",
+    "uuid": "^8.3.2"
   },
   "devDependencies": {
     "@types/form-data": "^2.5.0",

--- a/pages/api/addToMailingList.ts
+++ b/pages/api/addToMailingList.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import Mailgun from 'mailgun-js'
-import { uuidIsValid } from '../../lib/uuid'
+import { verifyUUID } from '../../lib/uuid'
 
 export default (req: NextApiRequest, res: NextApiResponse) => (
   new Promise(resolve => {
@@ -10,7 +10,7 @@ export default (req: NextApiRequest, res: NextApiResponse) => (
     const mailgun = Mailgun
     const mg = mailgun({ apiKey: `${process.env.MAILGUN_API_KEY}`, domain: 'purduehackers.com' })
   
-    uuidIsValid(email as string, uuid as string)
+    verifyUUID(email as string, uuid as string)
     .then(valid => {
       if (!valid) {
         console.log(`${email} did not provide the right UUID. Skipping...`)

--- a/pages/api/addToMailingList.ts
+++ b/pages/api/addToMailingList.ts
@@ -42,7 +42,10 @@ export default (req: NextApiRequest, res: NextApiResponse) => (
           })
           .catch(error => {
             if (error.toString().includes('Address already exists')) {
-              resolve(res.redirect(`/email-exists`))
+              deleteUUIDRecord(email as string)
+              .then(() => {
+                resolve(res.redirect(`/email-exists`))
+              })
             }
           })
         })

--- a/pages/api/addToMailingList.ts
+++ b/pages/api/addToMailingList.ts
@@ -10,7 +10,7 @@ export default (req: NextApiRequest, res: NextApiResponse) => (
     const mailgun = Mailgun
     const mg = mailgun({ apiKey: `${process.env.MAILGUN_API_KEY}`, domain: 'purduehackers.com' })
   
-    uuidIsValid(email, uuid)
+    uuidIsValid(email as string, uuid as string)
     .then(valid => {
       if (!valid) {
         resolve(res.redirect('/email-verification-failed'))
@@ -33,12 +33,14 @@ export default (req: NextApiRequest, res: NextApiResponse) => (
             subscribed: true,
             address: email as string,
             name: email as string,
-          }).then(() => {
-            deleteUUIDRecord(email)
+          })
+          .then(() => {
+            deleteUUIDRecord(email as string)
             .then(() => {
               resolve(res.redirect(`/email-confirm?eventName=${eventName}`))
             })
-          }).catch(error => {
+          })
+          .catch(error => {
             if (error.toString().includes('Address already exists')) {
               resolve(res.redirect(`/email-exists`))
             }

--- a/pages/api/addToMailingList.ts
+++ b/pages/api/addToMailingList.ts
@@ -1,6 +1,6 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import Mailgun from 'mailgun-js'
-import { deleteUUIDRecord, uuidIsValid } from '../../lib/uuid'
+import { uuidIsValid } from '../../lib/uuid'
 
 export default (req: NextApiRequest, res: NextApiResponse) => (
   new Promise(resolve => {
@@ -36,21 +36,11 @@ export default (req: NextApiRequest, res: NextApiResponse) => (
             name: email as string,
           })
           .then(async () => {
-            console.log('Deleting UUID record...')
-            await deleteUUIDRecord(email as string)
-            .then(() => {
-              console.log('Done!')
-              resolve(res.redirect(`/email-confirm?eventName=${eventName}`))
-            })
+            resolve(res.redirect(`/email-confirm?eventName=${eventName}`))
           })
           .catch(async (error) => {
             if (error.toString().includes('Address already exists')) {
-              console.log('Deleting UUID record...')
-              await deleteUUIDRecord(email as string)
-              .then(() => {
-                console.log('Done!')
-                resolve(res.redirect(`/email-exists`))
-              })
+              resolve(res.redirect(`/email-exists`))
             }
           })
         })

--- a/pages/api/addToMailingList.ts
+++ b/pages/api/addToMailingList.ts
@@ -35,18 +35,18 @@ export default (req: NextApiRequest, res: NextApiResponse) => (
             address: email as string,
             name: email as string,
           })
-          .then(() => {
+          .then(async () => {
             console.log('Deleting UUID record...')
-            deleteUUIDRecord(email as string)
+            await deleteUUIDRecord(email as string)
             .then(() => {
               console.log('Done!')
               resolve(res.redirect(`/email-confirm?eventName=${eventName}`))
             })
           })
-          .catch(error => {
+          .catch(async (error) => {
             if (error.toString().includes('Address already exists')) {
               console.log('Deleting UUID record...')
-              deleteUUIDRecord(email as string)
+              await deleteUUIDRecord(email as string)
               .then(() => {
                 console.log('Done!')
                 resolve(res.redirect(`/email-exists`))

--- a/pages/api/addToMailingList.ts
+++ b/pages/api/addToMailingList.ts
@@ -13,6 +13,7 @@ export default (req: NextApiRequest, res: NextApiResponse) => (
     uuidIsValid(email as string, uuid as string)
     .then(valid => {
       if (!valid) {
+        console.log(`${email} did not provide the right UUID. Skipping...`)
         resolve(res.redirect('/email-verification-failed'))
         return
       } else {
@@ -35,15 +36,19 @@ export default (req: NextApiRequest, res: NextApiResponse) => (
             name: email as string,
           })
           .then(() => {
+            console.log('Deleting UUID record...')
             deleteUUIDRecord(email as string)
             .then(() => {
+              console.log('Done!')
               resolve(res.redirect(`/email-confirm?eventName=${eventName}`))
             })
           })
           .catch(error => {
             if (error.toString().includes('Address already exists')) {
+              console.log('Deleting UUID record...')
               deleteUUIDRecord(email as string)
               .then(() => {
+                console.log('Done!')
                 resolve(res.redirect(`/email-exists`))
               })
             }

--- a/pages/api/addToMailingList.ts
+++ b/pages/api/addToMailingList.ts
@@ -1,38 +1,50 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import Mailgun from 'mailgun-js'
+import { deleteUUIDRecord, uuidIsValid } from '../../lib/uuid'
 
 export default (req: NextApiRequest, res: NextApiResponse) => (
   new Promise(resolve => {
-    const { list, email, eventName } = req.query
+    const { list, email, eventName, uuid } = req.query
 
     console.log(`Adding email ${email} to mailing list ${list}`)
     const mailgun = Mailgun
     const mg = mailgun({ apiKey: `${process.env.MAILGUN_API_KEY}`, domain: 'purduehackers.com' })
   
-    mg.get('/lists/pages')
-      .then(pages => pages.items)
-      .then(items => items.find((item: any) => item.name === list))
-      .then(async item => {
-        if (item === undefined) {
-          await mg.post('/lists', {
-            address: `${list}@purduehackers.com`,
-            description: list
-          })
-          .catch(err => {})
-        }
-      })
-      .then(() => {
-        mg.lists(`${list}@purduehackers.com`).members().create({
-          subscribed: true,
-          address: email as string,
-          name: email as string,
-        }).then(() => {
-          resolve(res.redirect(`/email-confirm?eventName=${eventName}`))
-        }).catch(error => {
-          if (error.toString().includes('Address already exists')) {
-            resolve(res.redirect(`/email-exists`))
+    uuidIsValid(email, uuid)
+    .then(valid => {
+      if (!valid) {
+        resolve(res.redirect('/email-verification-failed'))
+        return
+      } else {
+        mg.get('/lists/pages')
+        .then(pages => pages.items)
+        .then(items => items.find((item: any) => item.name === list))
+        .then(async item => {
+          if (item === undefined) {
+            await mg.post('/lists', {
+              address: `${list}@purduehackers.com`,
+              description: list
+            })
+            .catch(err => {})
           }
         })
-      })
+        .then(() => {
+          mg.lists(`${list}@purduehackers.com`).members().create({
+            subscribed: true,
+            address: email as string,
+            name: email as string,
+          }).then(() => {
+            deleteUUIDRecord(email)
+            .then(() => {
+              resolve(res.redirect(`/email-confirm?eventName=${eventName}`))
+            })
+          }).catch(error => {
+            if (error.toString().includes('Address already exists')) {
+              resolve(res.redirect(`/email-exists`))
+            }
+          })
+        })
+      }
+    })
   })
 )

--- a/pages/api/verifyEmail.ts
+++ b/pages/api/verifyEmail.ts
@@ -13,7 +13,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     from: 'Purdue Hackers <events@purduehackers.com>',
     to: `${email}`,
     subject: `Purdue Hackers: Please verify your email`,
-    template: 'verify-git-branch-uuid', 'h:X-Mailgun-Variables': JSON.stringify({ eventName, list: slug, email, uuid })
+    template: 'verify-your-email', 'h:X-Mailgun-Variables': JSON.stringify({ eventName, list: slug, email, uuid })
   }
 
   mg.messages().send(data)

--- a/pages/api/verifyEmail.ts
+++ b/pages/api/verifyEmail.ts
@@ -1,16 +1,19 @@
 import { NextApiRequest, NextApiResponse } from 'next'
 import Mailgun from 'mailgun-js'
+import { generateUUID } from '../../lib/uuid'
 
 export default async (req: NextApiRequest, res: NextApiResponse) => {
   const { email, eventName, slug } = req.body
   const mailgun = Mailgun
   const mg = mailgun({ apiKey: `${process.env.MAILGUN_API_KEY}`, domain: 'purduehackers.com' })
 
+  const uuid = await generateUUID(email)
+
   const data = {
     from: 'Purdue Hackers <events@purduehackers.com>',
     to: `${email}`,
     subject: `Purdue Hackers: Please verify your email`,
-    template: 'verify-your-email', 'h:X-Mailgun-Variables': JSON.stringify({ eventName, list: slug, email })
+    template: 'verify-your-email', 'h:X-Mailgun-Variables': JSON.stringify({ eventName, list: slug, email, uuid })
   }
 
   mg.messages().send(data)

--- a/pages/api/verifyEmail.ts
+++ b/pages/api/verifyEmail.ts
@@ -13,7 +13,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     from: 'Purdue Hackers <events@purduehackers.com>',
     to: `${email}`,
     subject: `Purdue Hackers: Please verify your email`,
-    template: 'verify-your-email', 'h:X-Mailgun-Variables': JSON.stringify({ eventName, list: slug, email, uuid })
+    template: 'verify-git-branch-uuid', 'h:X-Mailgun-Variables': JSON.stringify({ eventName, list: slug, email, uuid })
   }
 
   mg.messages().send(data)

--- a/pages/email-verification-failed.tsx
+++ b/pages/email-verification-failed.tsx
@@ -27,7 +27,7 @@ const EmailConfirm = () => {
           </p>
           <p>
             If you did that and you're still seeing this, shoot an email to{' '}
-            <StyledLink destination="mailto:mstanciu@purdue.edu">mstanciu@purdue.edu</StyledLink>.
+            <StyledLink destination="mailto:mstanciu@purdue.edu" color="text-blue-600 hover:text-blue-500">mstanciu@purdue.edu</StyledLink>.
           </p>
         </div>
       </div>

--- a/pages/email-verification-failed.tsx
+++ b/pages/email-verification-failed.tsx
@@ -1,0 +1,39 @@
+import { useTheme } from 'next-themes'
+import BackButton from '../components/back-button'
+import StyledLink from '../components/styled-link'
+import ThemeButton from '../components/theme-button'
+
+const EmailConfirm = () => {
+  const { resolvedTheme } = useTheme()
+
+  return (
+    <main>
+      <div className="flex flex-row bg-gray-100 dark:bg-gray-800">
+        <BackButton />
+        {resolvedTheme && (
+          <ThemeButton />
+        )}
+      </div>
+      <div className="flex items-center justify-center h-screen -my-12 sm:-my-14">
+      <div className="container mx-auto px-4 md:px-16 lg:px-72 xl:px-96">
+        <div className="rounded-lg shadow-md bg-red-200 dark:bg-red-900 p-4 flex flex-col justify-center gap-y-3">
+          <h1 className="text-2xl sm:text-3xl font-bold text-center">Couldn't add you to the list :(</h1>
+          <p>
+            We couldn't add you to the mailing list :( this usually happens if you clicked a button on an old email.
+          </p>
+          <p>
+            Try signing up to receive reminders again on the event page. Make sure to wait for a new email to arrive &{' '}
+            click on that email's button.
+          </p>
+          <p>
+            If you did that and you're still seeing this, shoot an email to{' '}
+            <StyledLink destination="mailto:mstanciu@purdue.edu">mstanciu@purdue.edu</StyledLink>.
+          </p>
+        </div>
+      </div>
+    </div>
+    </main>
+  )
+}
+
+export default EmailConfirm

--- a/yarn.lock
+++ b/yarn.lock
@@ -268,6 +268,11 @@
   resolved "https://registry.yarnpkg.com/@types/scheduler/-/scheduler-0.16.2.tgz#1a62f89525723dde24ba1b01b092bf5df8ad4d39"
   integrity sha512-hppQEBDmlwhFAXKJX2KnWLYu5yMfi91yazPb2l+lbJiwW+wdo1gNeRA+3RgNSO39WYX2euey41KEwnqesU2Jew==
 
+"@types/uuid@^8.3.3":
+  version "8.3.3"
+  resolved "https://registry.yarnpkg.com/@types/uuid/-/uuid-8.3.3.tgz#c6a60686d953dbd1b1d45e66f4ecdbd5d471b4d0"
+  integrity sha512-0LbEEx1zxrYB3pgpd1M5lEhLcXjKJnYghvhTRgaBeUivLHMDM1TzF3IJ6hXU2+8uA4Xz+5BA63mtZo5DjVT8iA==
+
 abort-controller@^3.0.0:
   version "3.0.0"
   resolved "https://registry.yarnpkg.com/abort-controller/-/abort-controller-3.0.0.tgz#eaf54d53b62bae4138e809ca225c8439a6efb392"
@@ -3063,6 +3068,11 @@ util@0.12.4, util@^0.12.0:
     is-typed-array "^1.1.3"
     safe-buffer "^5.1.2"
     which-typed-array "^1.1.2"
+
+uuid@^8.3.2:
+  version "8.3.2"
+  resolved "https://registry.yarnpkg.com/uuid/-/uuid-8.3.2.tgz#80d5b5ced271bb9af6c445f21a1a04c606cefbe2"
+  integrity sha512-+NYs2QeMWy+GWFOEm9xnn6HCDp0l7QBD7ml8zLUmJ+93Q5NF0NocErnwkTkXVFNiX3/fpC6afS8Dhb/gz7R7eg==
 
 vm-browserify@1.1.2:
   version "1.1.2"


### PR DESCRIPTION
Previously, you could hit the `addToMailingList` API route with any email and add that email to the mailing list. Nobody actually cares enough to do that, but it still makes sense to assign a UUID to each person.