### PR TITLE
Add RSVP count to Airtable

### DIFF
--- a/.prettierrc
+++ b/.prettierrc
@@ -1,6 +1,6 @@
 {
   "singleQuote": true,
-  "trailingComma": "all",
+  "trailingComma": "none",
   "printWidth": 80,
   "semi": false
 }

--- a/lib/fetchEvents.ts
+++ b/lib/fetchEvents.ts
@@ -20,6 +20,7 @@ interface AirtableFields {
   'Custom Slug': string
   'Reminder Email Sent': boolean
   Unlisted: boolean
+  'RSVP Count': number
 }
 
 export const fetchEvents = async (): Promise<PHEvent[]> => {
@@ -40,6 +41,7 @@ export const fetchEvents = async (): Promise<PHEvent[]> => {
     emailSent: fields['Reminder Email Sent'] ?? false,
     unlisted: fields['Unlisted'] ?? false,
     slug: fields['Custom Slug'] ?? slugger.slug(fields['Event Name']),
+    rsvpCount: fields['RSVP Count'],
   }))
 
   return orderBy(events, 'start')

--- a/lib/fetchEvents.ts
+++ b/lib/fetchEvents.ts
@@ -40,7 +40,7 @@ export const fetchEvents = async (): Promise<PHEvent[]> => {
     calLink: fields['Calendar Link'] ?? false,
     emailSent: fields['Reminder Email Sent'] ?? false,
     unlisted: fields['Unlisted'] ?? false,
-    rsvpCount: fields['RSVP Count'],
+    rsvpCount: fields['RSVP Count'] ?? 0,
     slug: fields['Custom Slug'] ?? slugger.slug(fields['Event Name']),
   }))
 

--- a/lib/fetchEvents.ts
+++ b/lib/fetchEvents.ts
@@ -40,8 +40,8 @@ export const fetchEvents = async (): Promise<PHEvent[]> => {
     calLink: fields['Calendar Link'] ?? false,
     emailSent: fields['Reminder Email Sent'] ?? false,
     unlisted: fields['Unlisted'] ?? false,
-    slug: fields['Custom Slug'] ?? slugger.slug(fields['Event Name']),
     rsvpCount: fields['RSVP Count'],
+    slug: fields['Custom Slug'] ?? slugger.slug(fields['Event Name']),
   }))
 
   return orderBy(events, 'start')

--- a/lib/typings/events.d.ts
+++ b/lib/typings/events.d.ts
@@ -10,4 +10,5 @@ interface PHEvent {
   slug: string
   emailSent: boolean
   unlisted: boolean
+  rsvpCount: number
 }

--- a/lib/typings/mailgunapi.d.ts
+++ b/lib/typings/mailgunapi.d.ts
@@ -1,5 +1,5 @@
 interface MailingListData {
-  name: string
+  description: string
   members_count: number
 }
 

--- a/lib/typings/mailgunapi.d.ts
+++ b/lib/typings/mailgunapi.d.ts
@@ -1,0 +1,8 @@
+interface MailingListData {
+  name: string
+  members_count: number
+}
+
+interface Pages {
+  items: MailingListData[]
+}

--- a/pages/api/addToMailingList.ts
+++ b/pages/api/addToMailingList.ts
@@ -54,7 +54,8 @@ export default (req: NextApiRequest, res: NextApiResponse) =>
                 console.log('Updating values in Airtable')
                 airtable
                   .updateWhere(`{Event Name} = '${eventName}'`, {
-                    'RSVP Count': item.members_count + 1
+                    'RSVP Count':
+                      item !== undefined ? item?.members_count + 1 : 1
                   })
                   .then(() => {
                     console.log('Done!')

--- a/pages/api/verifyEmail.ts
+++ b/pages/api/verifyEmail.ts
@@ -7,7 +7,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
   const mailgun = Mailgun
   const mg = mailgun({
     apiKey: `${process.env.MAILGUN_API_KEY}`,
-    domain: 'purduehackers.com',
+    domain: 'purduehackers.com'
   })
 
   const uuid = await generateUUID(email)
@@ -21,14 +21,14 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
       eventName,
       list: slug,
       email,
-      uuid,
-    }),
+      uuid
+    })
   }
 
   mg.messages()
     .send(data)
     .then((r) => {
-      console.log('Successfully sent verification email!')
+      console.log(`Successfully sent verification email to ${email}!`)
       console.log(r)
       res.json({ ok: true, status: 200 })
     })

--- a/pages/api/verifyEmail.ts
+++ b/pages/api/verifyEmail.ts
@@ -16,7 +16,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     from: 'Purdue Hackers <events@purduehackers.com>',
     to: `${email}`,
     subject: `Purdue Hackers: Please verify your email`,
-    template: 'verify-your-email',
+    template: 'verify-git-branch-uuid',
     'h:X-Mailgun-Variables': JSON.stringify({
       eventName,
       list: slug,

--- a/pages/api/verifyEmail.ts
+++ b/pages/api/verifyEmail.ts
@@ -16,7 +16,7 @@ export default async (req: NextApiRequest, res: NextApiResponse) => {
     from: 'Purdue Hackers <events@purduehackers.com>',
     to: `${email}`,
     subject: `Purdue Hackers: Please verify your email`,
-    template: 'verify-git-branch-uuid',
+    template: 'verify-your-email',
     'h:X-Mailgun-Variables': JSON.stringify({
       eventName,
       list: slug,


### PR DESCRIPTION
Right now it's a little inconvenient to have to sign into Mailgun to see how many people signed up for an event. This information should be easily available in Airtable.