### PR TITLE
feat(gallery): serve event images through Vercel's image optimizer

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -5,28 +5,24 @@ import tailwindcss from "@tailwindcss/vite";
 import react from "@astrojs/react";
 import vercel from "@astrojs/vercel";
 
-// https://astro.build/config
 export default defineConfig({
-  //output: "server",
   site: "https://events.purduehackers.com",
   adapter: vercel({
     isr: {
       expiration: 60 * 60 * 24,
-      exclude: ['/api/events', '/api/rsvps'] 
+      exclude: ['/api/events', '/api/rsvps']
+    },
+    imageService: true,
+    imagesConfig: {
+      sizes: [400, 800, 1200, 1600, 2400],
+      domains: ['cms.purduehackers.com'],
     },
   }),
+  image: {
+    domains: ['cms.purduehackers.com'],
+  },
   vite: {
     plugins: [tailwindcss()],
-    /*server: {
-      proxy: {
-        // Proxy API requests during local dev to avoid CORS issues
-        "/api/events": {
-          target: process.env.PUBLIC_CMS_URL ?? "https://cms.purduehackers.com",
-          changeOrigin: true,
-          rewrite: (path) => path.replace(/^\/api\/events/, "/api/events"),
-        },
-      },
-    },*/
   },
   integrations: [react()],
 });

--- a/src/components/past-events/Gallery.astro
+++ b/src/components/past-events/Gallery.astro
@@ -1,20 +1,45 @@
 ---
-interface ImageItem {
+import { optimizedSrcset, optimizedUrl } from "../../utilities/image.ts";
+
+interface ImageInput {
   url: string;
   alt?: string;
+  width?: number;
+  height?: number;
 }
 
 interface Props {
-  images?: Array<ImageItem | string>;
+  images?: Array<ImageInput | string>;
 }
+
+interface ImageItem {
+  url: string;
+  alt: string;
+  width?: number;
+  height?: number;
+  thumbSrc: string;
+  thumbSrcset: string;
+  lightboxSrc: string;
+  lightboxSrcset: string;
+}
+
+const THUMB_WIDTHS = [400, 800, 1200];
+const LIGHTBOX_WIDTHS = [800, 1200, 1600, 2400];
 
 const { images = [] } = Astro.props;
 
 const imageItems: ImageItem[] = images.map((img) => {
-  if (typeof img === "string") {
-    return { url: img, alt: "Event photo" };
-  }
-  return { url: img.url, alt: img.alt ?? "Event photo" };
+  const input: ImageInput = typeof img === "string" ? { url: img } : img;
+  return {
+    url: input.url,
+    alt: input.alt ?? "Event photo",
+    width: input.width,
+    height: input.height,
+    thumbSrc: optimizedUrl(input.url, 800),
+    thumbSrcset: optimizedSrcset(input.url, THUMB_WIDTHS),
+    lightboxSrc: optimizedUrl(input.url, 1600),
+    lightboxSrcset: optimizedSrcset(input.url, LIGHTBOX_WIDTHS),
+  };
 });
 ---
 
@@ -202,12 +227,14 @@ const imageItems: ImageItem[] = images.map((img) => {
             const prevIndex =
                 (currentImageIndex - 1 + allImageItems.length) %
                 allImageItems.length;
-            new Image().src = allImageItems[nextIndex].url;
-            new Image().src = allImageItems[prevIndex].url;
+            new Image().src = allImageItems[nextIndex].lightboxSrc;
+            new Image().src = allImageItems[prevIndex].lightboxSrc;
 
-            lightboxImg.src = allImageItems[currentImageIndex].url;
-            lightboxImg.alt =
-                allImageItems[currentImageIndex].alt ?? "Event photo";
+            const current = allImageItems[currentImageIndex];
+            lightboxImg.src = current.lightboxSrc;
+            lightboxImg.srcset = current.lightboxSrcset;
+            lightboxImg.sizes = "100vw";
+            lightboxImg.alt = current.alt ?? "Event photo";
         }
     };
 
@@ -280,7 +307,7 @@ const imageItems: ImageItem[] = images.map((img) => {
 
         for (let i = 0; i < image_count; i++) {
             const isHidden = i >= 3;
-            const { url: img_url, alt: img_alt } = allImageItems[i];
+            const item = allImageItems[i];
 
             const img_wrapper = document.createElement("div");
 
@@ -294,9 +321,15 @@ const imageItems: ImageItem[] = images.map((img) => {
             img_wrapper.onclick = () => openLightbox(i);
 
             const img = document.createElement("img");
-            img.src = img_url;
-            img.alt = img_alt ?? "Event photo";
+            img.src = item.thumbSrc;
+            img.srcset = item.thumbSrcset;
+            img.sizes = "(min-width: 768px) 33vw, 50vw";
+            img.alt = item.alt ?? "Event photo";
             img.className = "rounded-xs w-full";
+            img.loading = isHidden || i >= 3 ? "lazy" : "eager";
+            img.decoding = "async";
+            if (item.width) img.width = item.width;
+            if (item.height) img.height = item.height;
 
             img_wrapper.appendChild(img);
             imageArea.appendChild(img_wrapper);

--- a/src/components/past-events/Gallery.astro
+++ b/src/components/past-events/Gallery.astro
@@ -1,5 +1,5 @@
 ---
-import { optimizedSrcset, optimizedUrl } from "../../utilities/image.ts";
+import { optimizedSrcset, optimizedUrl } from "../../utilities/image";
 
 interface ImageInput {
   url: string;
@@ -35,9 +35,9 @@ const imageItems: ImageItem[] = images.map((img) => {
     alt: input.alt ?? "Event photo",
     width: input.width,
     height: input.height,
-    thumbSrc: optimizedUrl(input.url, 800),
+    thumbSrc: optimizedUrl(input.url, THUMB_WIDTHS[0]),
     thumbSrcset: optimizedSrcset(input.url, THUMB_WIDTHS),
-    lightboxSrc: optimizedUrl(input.url, 1600),
+    lightboxSrc: optimizedUrl(input.url, LIGHTBOX_WIDTHS[0]),
     lightboxSrcset: optimizedSrcset(input.url, LIGHTBOX_WIDTHS),
   };
 });
@@ -231,9 +231,9 @@ const imageItems: ImageItem[] = images.map((img) => {
             new Image().src = allImageItems[prevIndex].lightboxSrc;
 
             const current = allImageItems[currentImageIndex];
-            lightboxImg.src = current.lightboxSrc;
             lightboxImg.srcset = current.lightboxSrcset;
             lightboxImg.sizes = "100vw";
+            lightboxImg.src = current.lightboxSrc;
             lightboxImg.alt = current.alt ?? "Event photo";
         }
     };
@@ -321,12 +321,12 @@ const imageItems: ImageItem[] = images.map((img) => {
             img_wrapper.onclick = () => openLightbox(i);
 
             const img = document.createElement("img");
-            img.src = item.thumbSrc;
             img.srcset = item.thumbSrcset;
             img.sizes = "(min-width: 768px) 33vw, 50vw";
+            img.src = item.thumbSrc;
             img.alt = item.alt ?? "Event photo";
             img.className = "rounded-xs w-full";
-            img.loading = isHidden || i >= 3 ? "lazy" : "eager";
+            img.loading = isHidden ? "lazy" : "eager";
             img.decoding = "async";
             if (item.width) img.width = item.width;
             if (item.height) img.height = item.height;

--- a/src/pages/events/[event].astro
+++ b/src/pages/events/[event].astro
@@ -129,6 +129,8 @@ const {
                 images={event.images.map((img) => ({
                   url: img.image.url,
                   alt: img.image?.alt ?? event.name,
+                  width: img.image.width,
+                  height: img.image.height,
                 }))}
               />
             )}

--- a/src/utilities/image.ts
+++ b/src/utilities/image.ts
@@ -1,0 +1,25 @@
+const DEFAULT_WIDTHS = [400, 800, 1200, 1600];
+const DEFAULT_QUALITY = 75;
+
+function encodeUrl(url: string): string {
+  return encodeURIComponent(url);
+}
+
+/**
+ * Wraps a remote image URL through Vercel's on-the-fly image optimizer.
+ * The source hostname must be allow-listed in `imagesConfig.domains`
+ * (see astro.config.mjs). Non-remote URLs are returned unchanged.
+ */
+export function optimizedUrl(url: string, width: number, quality = DEFAULT_QUALITY): string {
+  if (!url.startsWith("http")) return url;
+  return `/_vercel/image?url=${encodeUrl(url)}&w=${width}&q=${quality}`;
+}
+
+export function optimizedSrcset(
+  url: string,
+  widths: number[] = DEFAULT_WIDTHS,
+  quality = DEFAULT_QUALITY,
+): string {
+  if (!url.startsWith("http")) return url;
+  return widths.map((w) => `${optimizedUrl(url, w, quality)} ${w}w`).join(", ");
+}


### PR DESCRIPTION
## Summary

- Enable Vercel's `imageService` in `@astrojs/vercel`, allow-list `cms.purduehackers.com` in `imagesConfig`, so `/_vercel/image?url=…&w=…&q=…` is served on our domain.
- Tiny helper `src/utilities/image.ts` (`optimizedUrl`, `optimizedSrcset`) that wraps remote Payload URLs through the optimizer.
- `Gallery.astro`: precompute thumbnail + lightbox `src`/`srcset` pairs in the server frontmatter and pass them into the client script. Thumbnails use widths `[400, 800, 1200]`; lightbox uses `[800, 1200, 1600, 2400]`. Offscreen tiles get `loading="lazy"` (first three stay `eager`), and width/height are threaded through Payload's media metadata so browsers reserve space and stop layout-shifting.
- `[event].astro`: forward `image.width` / `image.height` from Payload into the Gallery props.

## Why

Event pages currently ship multi-MB full-resolution originals for every image. Lighthouse flags both the transfer size and layout shift.

## Test plan

- [ ] `pnpm install && pnpm build` clean
- [ ] Inspect DevTools Network on a populated past-event page: `<img>` requests hit `/_vercel/image?url=…` not raw `cms.purduehackers.com/api/media/file/…`, transfer sizes in the low hundreds of KB, `Content-Type` is `image/webp` (or AVIF)
- [ ] Lightbox navigates between images; preloads use the optimized URL
- [ ] Click a grid thumbnail → lightbox shows a higher-resolution variant

🤖 Generated with [Claude Code](https://claude.com/claude-code)